### PR TITLE
[package.xml] Add and refactor dependencies

### DIFF
--- a/livox_ros2_driver/package.xml
+++ b/livox_ros2_driver/package.xml
@@ -9,15 +9,17 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>rosbag</build_depend>
-  <build_depend>livox_interfaces</build_depend>
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>livox_interfaces</depend>
+  <depend>sensor_msgs</depend>
+  <depend>rcutils</depend>
+  <depend>pcl_conversions</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>libpcl-all-dev</depend>
 
+  <exec_depend>rosbag2</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>livox_interfaces</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
In building the livox_ros2_driver with foxy, I was successful but I had to clean up the dependencies such that a 

    rosdep install --from-paths src/vendor/livox/  --ignore-src --rosdistro foxy -y

installs all the dependencies within https://github.com/tier4/autoware_launcher.iv.universe/pull/14. I tested this in the ADE provided by Autoware.Auto that has a cleaner env to start with. I guess this driver build on your machine because the dependencies like PCL were installed by hand.