### PR TITLE
Use vendor package for finding Livox-SDK libraries and headers

### DIFF
--- a/livox_ros2_driver/CMakeLists.txt
+++ b/livox_ros2_driver/CMakeLists.txt
@@ -35,6 +35,8 @@ find_package(pcl_conversions REQUIRED)
 find_package(rcl_interfaces REQUIRED)
 find_package(livox_interfaces REQUIRED)
 find_package(PCL REQUIRED)
+find_package(livox_sdk_vendor REQUIRED)
+find_package(livox_sdk REQUIRED)
 
 # check apr
 find_package(PkgConfig)
@@ -66,6 +68,8 @@ ament_target_dependencies(${PROJECT_NAME}_node
   sensor_msgs
   std_msgs
   livox_interfaces)
+
+target_include_directories(${PROJECT_NAME}_node PRIVATE ${livox_sdk_INCLUDE_DIRS})
 
 target_sources(${PROJECT_NAME}_node
 	PRIVATE
@@ -101,7 +105,7 @@ target_include_directories(${PROJECT_NAME}_node
 
 # link libraries
 target_link_libraries(${PROJECT_NAME}_node 	
-	livox_sdk_static.a
+	${livox_sdk_LIBRARIES}
 	${Boost_LIBRARY}
 	${rclcpp_LIBRARIES}
 	${PCL_LIBRARIES}

--- a/livox_ros2_driver/package.xml
+++ b/livox_ros2_driver/package.xml
@@ -17,6 +17,7 @@
   <depend>pcl_conversions</depend>
   <depend>rcl_interfaces</depend>
   <depend>libpcl-all-dev</depend>
+  <depend>livox_sdk_vendor</depend>
 
   <exec_depend>rosbag2</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>


### PR DESCRIPTION
I've created a vendor package in https://github.com/tier4/livox_sdk_vendor that will either find the Livox SDK in the system or fetch it from the internet and build it. Adding the `livox_sdk_vendor` package to a `colcon` workspace is simple, just clone it and it'll make the Livox SDK available to downstream packages that declare `livox_sdk_vendor` as a dependency.