### PR TITLE
Fix for compilation error regarding logging

### DIFF
--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -586,7 +586,7 @@ std::shared_ptr<rclcpp::PublisherBase> Lddc::CreatePublisher(uint8_t msg_type,
           sensor_msgs::msg::PointCloud2>(topic_name, queue_size);
     } else if (kLivoxCustomMsg == msg_type) {
       RCLCPP_INFO(cur_node_->get_logger(),
-          "%s publish use livox custom format", topic_name);
+          "%s publish use livox custom format", topic_name.c_str());
       return cur_node_->create_publisher<
           livox_interfaces::msg::CustomMsg>(topic_name, queue_size);
     }


### PR DESCRIPTION
Fix for compilation error due to lack of conversion from std::string to c_string which is needed by logging function.